### PR TITLE
YP6M-2955 Add archetype integration tests + CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    uses: p6m-archetypes/archetype-test-harness/.github/workflows/archetype-test.yaml@main
+    uses: p6m-workflows/archetype-test/.github/workflows/workflow.yml@v1
     with:
       harness-ref: main
       # This archetype uses a Rhai script and requires archetect 2.x (3.x refuses .rhai);

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: Test Archetype
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    uses: p6m-archetypes/archetype-test-harness/.github/workflows/archetype-test.yaml@main
+    with:
+      harness-ref: main
+      # This archetype uses a Rhai script and requires archetect 2.x (3.x refuses .rhai);
+      # 2.x versions are installed as archetect2, which the harness resolves automatically
+      archetect-version: "2.1.2"
+      toolchain: node
+      toolchain-version: "22"
+    secrets: inherit

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+.pytest_cache/
+__pycache__/
+node_modules/
+.next/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,62 @@
+# Archetype integration tests
+
+This archetype is tested by the shared
+[archetype-test-harness](https://github.com/p6m-archetypes/archetype-test-harness):
+it renders the archetype headlessly with the answers in [answers/](answers/), checks
+the generated project (expected files present, no unrendered `{{ placeholder }}`
+tokens, generated YAML parses), and builds the generated Next.js project with pnpm.
+This directory holds only data - the test code lives in the harness repo.
+
+One `default` case is covered (renders into `customer-frontend`).
+
+## Prerequisites
+
+- [archetect](https://archetect.github.io/) **2.x** - this archetype uses a Rhai
+  script, which archetect 3.x refuses to render. Install v2 alongside v3:
+
+  ```sh
+  brew install archetect/tap/archetect@2
+  ln -s /opt/homebrew/opt/archetect@2/bin/archetect /opt/homebrew/bin/archetect2
+  ```
+
+  The harness reads `requires.archetect` from [archetype.yaml](../archetype.yaml)
+  and looks for `$ARCHETECT2`, then `archetect2` on PATH, then the homebrew keg.
+- [uv](https://docs.astral.sh/uv/) on PATH (`brew install uv`)
+- Network access to GitHub - the archetype composes prompt/manifest components from
+  git sources; archetect caches them after the first render
+- [pnpm](https://pnpm.io/) for the build tier (optional - build tests skip with a
+  notice when `pnpm` is not on PATH). pnpm is the generated project's package
+  manager (it ships a `pnpm-lock.yaml`).
+
+## Running
+
+From the repo root (or this directory):
+
+```sh
+# in the flat org checkout, against the sibling harness:
+uvx --from ../archetype-test-harness archetype-test
+
+# anywhere, against the published harness:
+uvx --from git+https://github.com/p6m-archetypes/archetype-test-harness@main archetype-test
+```
+
+Extra arguments pass through to pytest:
+
+```sh
+archetype-test -m "not build"   # fast tier only: render + static checks, no pnpm needed
+archetype-test --offline        # use archetect's cached component sources
+archetype-test -v -ra           # verbose, with skip/fail reasons
+```
+
+## CI
+
+[.github/workflows/test.yaml](../.github/workflows/test.yaml) calls the harness's
+reusable workflow with `archetect-version: 2.1.2` (installed as `archetect2`) on
+every push and manual dispatch. On failure it uploads the rendered project as a
+build artifact.
+
+## Adding a test case
+
+Add an entry to [manifest.yaml](manifest.yaml) plus an answers file under
+[answers/](answers/) - the schema is documented in the
+[harness README](https://github.com/p6m-archetypes/archetype-test-harness#manifestyaml-schema).

--- a/tests/answers/default.yaml
+++ b/tests/answers/default.yaml
@@ -1,0 +1,8 @@
+# Headless answers for the default test case.
+# Prompt keys come from archetype.rhai (kebab-case). Anything not listed here
+# falls back to prompt defaults via `archetect render -D`.
+# project-name is derived as "{{ project-prefix }}-frontend", so this renders
+# into a "customer-frontend" directory.
+org-name: "acme"
+project-title: "Customer"
+project-prefix: "customer"

--- a/tests/manifest.yaml
+++ b/tests/manifest.yaml
@@ -1,0 +1,57 @@
+# Test cases for this archetype. Each case is rendered once per pytest session
+# and shared by all tests that reference it.
+#
+# Fields:
+#   name           unique case id (shows up in test names)
+#   answers        answers file passed to `archetect render -A`, relative to tests/
+#   project_dir    directory the render is expected to produce (derived from the answers)
+#   expected_files paths (relative to project_dir) that must exist after rendering
+#   absent_files   paths (relative to project_dir) that must NOT exist after rendering
+#   requires       executables that must be on PATH for the build tier; missing -> build tests skip
+#   build_steps    commands run sequentially inside project_dir by the build tier
+#   env            extra environment variables for build_steps
+#   yaml_globs     globs (relative to project_dir) of generated files that must parse
+#                  as valid YAML; each glob must match at least one file
+cases:
+  - name: default
+    answers: answers/default.yaml
+    project_dir: customer-frontend
+    expected_files:
+      - package.json
+      - pnpm-lock.yaml
+      - next.config.js
+      - open-next.config.js
+      - postcss.config.mjs
+      - eslint.config.mjs
+      - tsconfig.json
+      - src/app/layout.tsx
+      - src/app/page.tsx
+      - Dockerfile
+      - .dockerignore
+      - .gitignore
+      - .platform/kubernetes/base/application.yaml
+      - .platform/kubernetes/base/kustomization.yaml
+      - .platform/kubernetes/dev/kustomization.yaml
+      - .platform/kubernetes/stg/kustomization.yaml
+      - .platform/kubernetes/prd/kustomization.yaml
+      - .github/workflows/build-branch.yaml
+      - .github/workflows/build-main.yaml
+      - .github/workflows/cut-tag.yaml
+      - .github/workflows/promote.yaml
+      - .github/workflows/release-tag.yaml
+    yaml_globs:
+      - ".platform/kubernetes/**/*.yaml"
+      - ".github/workflows/*.yaml"
+    requires:
+      # The generated project ships a pnpm-lock.yaml; pnpm is its package manager.
+      # The shared reusable workflow sets up Node only, so the build tier runs
+      # locally (where pnpm is on PATH) and skips in CI.
+      - pnpm
+    build_steps:
+      # pnpm 11 exits non-zero when a dependency's build scripts are ignored
+      # (esbuild/sharp/unrs-resolver here); dangerouslyAllowAllBuilds lets them run
+      # so the install succeeds in a headless, non-interactive environment.
+      - [pnpm, install, --frozen-lockfile, --config.dangerouslyAllowAllBuilds=true]
+      # verify-deps-before-run=false keeps pnpm's pre-run dependency check from
+      # re-triggering that same ignored-builds error before `next build` starts.
+      - [pnpm, --config.verify-deps-before-run=false, run, build]


### PR DESCRIPTION
## Summary

Adds the shared [archetype-test-harness](https://github.com/p6m-archetypes/archetype-test-harness) integration tests and a CI workflow to this archetype, following the reference pattern from `dotnet-rest-service-basic.archetype` adapted for a pnpm / Next.js frontend.

- `tests/` (data only): `manifest.yaml`, `answers/default.yaml`, `README.md`, `.gitignore`.
- `.github/workflows/test.yaml`: calls the harness reusable workflow on every push / manual dispatch with `archetect-version: 2.1.2` (Rhai/Gen-1), `toolchain: node`, `toolchain-version: 22`.

## Coverage

One `default` case (renders into `customer-frontend`):

- **Render tier:** expected files present, no unrendered `{{ }}` placeholders, generated k8s/workflow YAML parses.
- **Build tier:** `pnpm install --frozen-lockfile` + `pnpm run build` (Next.js production build).

## Validation

Ran locally against the sibling harness (with the YP6M-2954 fix) - all 6 checks pass, including the real `next build`.

## Dependencies

> [!IMPORTANT]
> Depends on **YP6M-2954** ([harness PR #4](https://github.com/p6m-archetypes/archetype-test-harness/pull/4)). The generated CI workflows use `docker/metadata-action` `{{is_default_branch}}` templating that the current harness misflags as an unrendered placeholder. **This repo's CI render tier stays red until that harness fix lands on the harness `main`.**

## Notes

- pnpm is the generated project's package manager. The shared reusable workflow sets up Node only, so the **build tier runs locally (pnpm on PATH) and skips in CI**; CI still runs the render + static checks.
- `--config.dangerouslyAllowAllBuilds` / `verify-deps-before-run=false` work around pnpm 11 refusing to run ignored dependency build scripts (esbuild/sharp) non-interactively.

Jira: YP6M-2955